### PR TITLE
送信できなかった report をログに書き出す

### DIFF
--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -81,7 +81,7 @@ module Bugsnag
             end
           end
 
-          report["_log_type"] = "bugsnag.unnotified_report"
+          report["_log_type"] = "unnotified_report.bugsnag"
           configuration.error(JSON.dump(report))
         end
       end

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -9,6 +9,7 @@ module Bugsnag
         # Attempts to deliver a payload to the given endpoint synchronously.
         def deliver(url, body, configuration, options={})
           begin
+            raise # wip
             response = request(url, body, configuration, options)
             configuration.debug("Request to #{url} completed, status: #{response.code}")
             if response.code[0] != "2"

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -81,7 +81,8 @@ module Bugsnag
             end
           end
 
-          configuration.error(JSON.dump({ "unnotifiedReport" => report }))
+          report["_log_type"] = "bugsnag.unnotified_report"
+          configuration.error(JSON.dump(report))
         end
       end
     end

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -9,7 +9,6 @@ module Bugsnag
         # Attempts to deliver a payload to the given endpoint synchronously.
         def deliver(url, body, configuration, options={})
           begin
-            raise # wip
             response = request(url, body, configuration, options)
             configuration.debug("Request to #{url} completed, status: #{response.code}")
             if response.code[0] != "2"

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -20,6 +20,9 @@ module Bugsnag
 
             configuration.error("Unable to send information to Bugsnag (#{url}), #{e.inspect}")
             configuration.error(e.backtrace)
+
+            # Rentio 拡張
+            log_unnotified_report(body, configuration)
           end
         end
 
@@ -60,6 +63,25 @@ module Bugsnag
             "Content-Type" => "application/json",
             "Bugsnag-Sent-At" => Time.now.utc.iso8601(3)
           }
+        end
+
+        # Rentio 拡張: 送信できなかった report をログに書き出す
+        def log_unnotified_report(body, configuration)
+          report = JSON.parse(body)
+
+          # 余分な情報を削る
+          report.delete("apiKey")
+          report["events"]&.each do |event|
+            event.delete("breadcrumbs")
+            event["exceptions"]&.each do |exception|
+              exception["stacktrace"]&.slice!(20..)
+              exception["stacktrace"]&.each do |stacktrace|
+                stacktrace.delete("code")
+              end
+            end
+          end
+
+          configuration.error(JSON.dump({ "unnotifiedReport" => report }))
         end
       end
     end


### PR DESCRIPTION
body という引数には Bugsnag の画面を作るのに必要そうな全情報 ([report](https://github.com/rentio/bugsnag-ruby/blob/caf3ecc9aa812af4df0275861a739da297e83398/lib/bugsnag/report.rb)) が入っています。

https://github.com/rentio/bugsnag-ruby/blob/caf3ecc9aa812af4df0275861a739da297e83398/lib/bugsnag.rb#L145 https://github.com/rentio/bugsnag-ruby/blob/caf3ecc9aa812af4df0275861a739da297e83398/lib/bugsnag.rb#L471-L476 https://github.com/rentio/bugsnag-ruby/blob/caf3ecc9aa812af4df0275861a739da297e83398/lib/bugsnag/delivery/synchronous.rb#L10

---

HomeController で

```rb
begin
  1 / 0
rescue => e
  Bugsnag.notify { |report| report.add_metadata(:foo, { a: 1 }) }
end
```

とした時の report は以下のような内容になります。(長いです)
https://rentiojp.slack.com/files/UFBDDB4SK/F03LQ3XGYDS/_____________bugsnag_report.js

---

このうち、以下の余分な情報を省いた report を1行の JSON でログに書き出すようにしました

- apiKey
- breadcrumb (画面でもここの見方よくわかってない)
- 21個目以降の深い stacktrace
- stacktrace 中の code

https://rentiojp.slack.com/files/UFBDDB4SK/F03LMMKQPAN/____________________________bugsnag_report.js